### PR TITLE
fix: update description from "type-safe" to "type-assisted" in README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2,7 +2,7 @@ Language: [EN](./README.md) / JA
 
 # neouter
 
-neouter($/njuːtər/$, ニョーター) is type-safe router for minimalists!
+neouter($/njuːtər/$, ニョーター) is type-assisted router for minimalists!
 
 ## インストール
 ```bash

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Language: EN / [JA](./README.ja.md)
 
 # neouter
 
-neouter($/njuːtər/$, ニョーター) is type-safe router for minimalists!
+neouter($/njuːtər/$, ニョーター) is type-assisted router for minimalists!
 
 ## Installation
 


### PR DESCRIPTION
流石にtype-safeは誇張表現なので、type-assistedに表記を変えた
このライブラリは、型安全性とNext.jsやwouter等に慣れている人にとっての直感的な使用感のバランスを取りたい