### PR TITLE
refactor: Use Navigation API

### DIFF
--- a/packages/neouter/src/components/Link.tsx
+++ b/packages/neouter/src/components/Link.tsx
@@ -1,30 +1,9 @@
 import type { ComponentProps } from 'react'
-import { useRouter } from '../hooks'
 import type { Path } from '../types'
 
 export const Link = ({
-  href,
   children,
   ...props
 }: ComponentProps<'a'> & { href: Path }) => {
-  const [, setLocation] = useRouter()
-  const { onClick, ...restProps } = props
-  return (
-    <a
-      href={href}
-      {...restProps}
-      onClick={(e) => {
-        onClick?.(e)
-        if (e.ctrlKey || e.metaKey) {
-          return
-        }
-        if (!e.defaultPrevented) {
-          e.preventDefault()
-          setLocation(href)
-        }
-      }}
-    >
-      {children}
-    </a>
-  )
+  return <a {...props}>{children}</a>
 }

--- a/packages/neouter/src/components/Redirect.tsx
+++ b/packages/neouter/src/components/Redirect.tsx
@@ -1,13 +1,10 @@
-import { useContext, useLayoutEffect } from 'react'
+import { useLayoutEffect } from 'react'
 import type { Path } from '..'
-import { RouterContext } from '../context'
 
 const Redirect = ({ path }: { path: Path }) => {
-  const { setLocation: _setLocation } = useContext(RouterContext)
   useLayoutEffect(() => {
-    _setLocation(path)
     window.history.replaceState({}, '', path)
-  }, [path, _setLocation])
+  }, [path])
   return null
 }
 

--- a/packages/neouter/src/components/Redirect.tsx
+++ b/packages/neouter/src/components/Redirect.tsx
@@ -1,10 +1,15 @@
-import { useLayoutEffect } from 'react'
+import { useContext, useLayoutEffect } from 'react'
 import type { Path } from '..'
+import { RouterContext } from '../context'
 
 const Redirect = ({ path }: { path: Path }) => {
+  const { setLocation } = useContext(RouterContext)
   useLayoutEffect(() => {
     window.history.replaceState({}, '', path)
-  }, [path])
+    if (!('navigation' in window)) {
+      setLocation(path)
+    }
+  }, [path, setLocation])
   return null
 }
 

--- a/packages/neouter/src/context.tsx
+++ b/packages/neouter/src/context.tsx
@@ -22,29 +22,36 @@ export const RouterProvider = ({
   useEffect(() => {
     if ('navigation' in window) {
       const handleNavigate = (e: NavigateEvent) => {
-        if (e.canIntercept) {
-          const destination = new URL(e.destination.url)
-          const nextPath = destination.pathname + destination.search
-          e.intercept({
-            async handler() {
-              startTransition(() => {
-                setLocation(nextPath)
-              })
-              const matchedPath = getMatchedPath(routes, nextPath)
-              const Component = matchedPath
-                ? routes[matchedPath]?.component
-                : null
-
-              if (
-                Component &&
-                'preload' in Component &&
-                typeof Component.preload === 'function'
-              ) {
-                await Component.preload()
-              }
-            },
-          })
+        if (
+          !e.canIntercept ||
+          e.hashChange ||
+          e.downloadRequest !== null ||
+          e.formData
+        ) {
+          return
         }
+
+        const destination = new URL(e.destination.url)
+        const nextPath = destination.pathname + destination.search
+        e.intercept({
+          async handler() {
+            startTransition(() => {
+              setLocation(nextPath)
+            })
+            const matchedPath = getMatchedPath(routes, nextPath)
+            const Component = matchedPath
+              ? routes[matchedPath]?.component
+              : null
+
+            if (
+              Component &&
+              'preload' in Component &&
+              typeof Component.preload === 'function'
+            ) {
+              await Component.preload()
+            }
+          },
+        })
       }
       navigation.addEventListener('navigate', handleNavigate)
       return () => {

--- a/packages/neouter/src/context.tsx
+++ b/packages/neouter/src/context.tsx
@@ -18,12 +18,22 @@ export const RouterProvider = ({
   )
 
   useEffect(() => {
-    const handlePopState = () => {
-      setLocation(window.location.pathname + window.location.search)
-    }
-    window.addEventListener('popstate', handlePopState)
-    return () => {
-      window.removeEventListener('popstate', handlePopState)
+    if ('navigation' in window) {
+      const handleNavigate = (e: NavigateEvent) => {
+        if (e.canIntercept) {
+          e.intercept({
+            async handler() {
+              setLocation(window.location.pathname + window.location.search)
+            },
+          })
+        }
+      }
+      navigation.addEventListener('navigate', handleNavigate)
+      return () => {
+        navigation.removeEventListener('navigate', handleNavigate)
+      }
+    } else {
+      // Older browsers will perform a full navigation to the new URL
     }
   }, [])
 

--- a/packages/neouter/src/context.tsx
+++ b/packages/neouter/src/context.tsx
@@ -1,17 +1,10 @@
-import {
-  createContext,
-  type Dispatch,
-  type SetStateAction,
-  useEffect,
-  useState,
-} from 'react'
+import { createContext, useEffect, useState } from 'react'
 import type { Path, Routes } from './types'
 
 export const RouterContext = createContext<{
   location: Path
-  setLocation: Dispatch<SetStateAction<string>>
   routes: Routes
-}>({ location: '', setLocation: () => {}, routes: {} })
+}>({ location: '', routes: {} })
 
 export const RouterProvider = ({
   routes,
@@ -35,7 +28,7 @@ export const RouterProvider = ({
   }, [])
 
   return (
-    <RouterContext.Provider value={{ location, setLocation, routes }}>
+    <RouterContext.Provider value={{ location, routes }}>
       {children}
     </RouterContext.Provider>
   )

--- a/packages/neouter/src/context.tsx
+++ b/packages/neouter/src/context.tsx
@@ -1,4 +1,4 @@
-import { createContext, useEffect, useState } from 'react'
+import { createContext, useEffect, useState, useTransition } from 'react'
 import type { Path, Routes } from './types'
 import { getMatchedPath } from './utils'
 
@@ -14,6 +14,7 @@ export const RouterProvider = ({
   routes: Routes
   children: React.ReactNode
 }) => {
+  const [, startTransition] = useTransition()
   const [location, setLocation] = useState(
     window.location.pathname + window.location.search
   )
@@ -26,7 +27,9 @@ export const RouterProvider = ({
           const nextPath = destination.pathname + destination.search
           e.intercept({
             async handler() {
-              setLocation(nextPath)
+              startTransition(() => {
+                setLocation(nextPath)
+              })
               const matchedPath = getMatchedPath(routes, nextPath)
               const Component = matchedPath
                 ? routes[matchedPath]?.component

--- a/packages/neouter/src/context.tsx
+++ b/packages/neouter/src/context.tsx
@@ -1,11 +1,19 @@
-import { createContext, useEffect, useState, useTransition } from 'react'
+import {
+  createContext,
+  type Dispatch,
+  type SetStateAction,
+  useEffect,
+  useState,
+  useTransition,
+} from 'react'
 import type { Path, Routes } from './types'
 import { getMatchedPath } from './utils'
 
 export const RouterContext = createContext<{
   location: Path
+  setLocation: Dispatch<SetStateAction<string>>
   routes: Routes
-}>({ location: '', routes: {} })
+}>({ location: '', setLocation: () => {}, routes: {} })
 
 export const RouterProvider = ({
   routes,
@@ -63,7 +71,7 @@ export const RouterProvider = ({
   }, [routes])
 
   return (
-    <RouterContext.Provider value={{ location, routes }}>
+    <RouterContext.Provider value={{ location, setLocation, routes }}>
       {children}
     </RouterContext.Provider>
   )

--- a/packages/neouter/src/context.tsx
+++ b/packages/neouter/src/context.tsx
@@ -1,5 +1,6 @@
 import { createContext, useEffect, useState } from 'react'
 import type { Path, Routes } from './types'
+import { getMatchedPath } from './utils'
 
 export const RouterContext = createContext<{
   location: Path
@@ -21,9 +22,23 @@ export const RouterProvider = ({
     if ('navigation' in window) {
       const handleNavigate = (e: NavigateEvent) => {
         if (e.canIntercept) {
+          const destination = new URL(e.destination.url)
+          const nextPath = destination.pathname + destination.search
           e.intercept({
             async handler() {
-              setLocation(window.location.pathname + window.location.search)
+              setLocation(nextPath)
+              const matchedPath = getMatchedPath(routes, nextPath)
+              const Component = matchedPath
+                ? routes[matchedPath]?.component
+                : null
+
+              if (
+                Component &&
+                'preload' in Component &&
+                typeof Component.preload === 'function'
+              ) {
+                await Component.preload()
+              }
             },
           })
         }
@@ -35,7 +50,7 @@ export const RouterProvider = ({
     } else {
       // Older browsers will perform a full navigation to the new URL
     }
-  }, [])
+  }, [routes])
 
   return (
     <RouterContext.Provider value={{ location, routes }}>

--- a/packages/neouter/src/hooks/useRouter.ts
+++ b/packages/neouter/src/hooks/useRouter.ts
@@ -3,11 +3,17 @@ import { RouterContext } from '../context'
 import type { Path } from '../types'
 
 export const useRouter = () => {
-  const { location } = useContext(RouterContext)
+  const { location, setLocation: _setLocation } = useContext(RouterContext)
 
-  const setLocation = useCallback((path: Path) => {
-    window.history.pushState({}, '', path)
-  }, [])
+  const setLocation = useCallback(
+    (path: Path) => {
+      window.history.pushState({}, '', path)
+      if (!('navigation' in window)) {
+        _setLocation(path)
+      }
+    },
+    [_setLocation]
+  )
 
   return [location, setLocation] as const
 }

--- a/packages/neouter/src/hooks/useRouter.ts
+++ b/packages/neouter/src/hooks/useRouter.ts
@@ -3,15 +3,11 @@ import { RouterContext } from '../context'
 import type { Path } from '../types'
 
 export const useRouter = () => {
-  const { location, setLocation: _setLocation } = useContext(RouterContext)
+  const { location } = useContext(RouterContext)
 
-  const setLocation = useCallback(
-    (path: Path) => {
-      _setLocation(path)
-      window.history.pushState({}, '', path)
-    },
-    [_setLocation]
-  )
+  const setLocation = useCallback((path: Path) => {
+    window.history.pushState({}, '', path)
+  }, [])
 
   return [location, setLocation] as const
 }

--- a/packages/neouter/src/types.ts
+++ b/packages/neouter/src/types.ts
@@ -1,3 +1,5 @@
+import type { ComponentType, JSX, LazyExoticComponent } from 'react'
+
 // biome-ignore lint/suspicious/noEmptyInterface: TODO
 export interface Register {}
 
@@ -55,6 +57,13 @@ type Path =
   | PathPattern
   | (WithQueryAndHash<AssertPathType<PathPattern>> & { _?: never }) // typescript is bad
 
+type PreloadableComponent<T extends ComponentType = ComponentType> =
+  LazyExoticComponent<T> & {
+    preload?: () => Promise<unknown>
+  }
+
+type RouteComponent = (() => JSX.Element) | PreloadableComponent
+
 export type {
   Routes,
   Path,
@@ -64,4 +73,6 @@ export type {
   QueryParamsValueType,
   AssertPathType,
   WithQueryAndHash,
+  PreloadableComponent,
+  RouteComponent,
 }

--- a/packages/neouter/src/utils/lazyImport.ts
+++ b/packages/neouter/src/utils/lazyImport.ts
@@ -1,11 +1,18 @@
 import type { ComponentType } from 'react'
 import { lazy } from 'react'
+import type { PreloadableComponent } from '..'
 
 export function lazyImport<
   U extends string,
   T extends { [P in U]: ComponentType },
->(factory: () => Promise<T>, name: U): T {
-  return Object.create({
-    [name]: lazy(() => factory().then((module) => ({ default: module[name] }))),
-  })
+>(
+  factory: () => Promise<T>,
+  name: U
+): { [P in U]: PreloadableComponent<T[U]> } {
+  const lazyComponent: PreloadableComponent<T[U]> = lazy(() =>
+    factory().then((module) => ({ default: module[name] }))
+  )
+  lazyComponent.preload = factory
+
+  return Object.create({ [name]: lazyComponent })
 }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,5 +1,4 @@
-import { lazyImport, redirect } from 'neouter'
-import type { JSX } from 'react'
+import { lazyImport, type RouteComponent, redirect } from 'neouter'
 import { About } from './routes/About'
 import { About2 } from './routes/About2'
 import { Home } from './routes/Home'
@@ -17,7 +16,7 @@ type PathPatterns =
   | '/users/:userId'
   | '/users/:userId/posts/:postId'
 
-export const routes: Record<PathPatterns, { component: () => JSX.Element }> = {
+export const routes: Record<PathPatterns, { component: RouteComponent }> = {
   '/': {
     component: Home,
   },


### PR DESCRIPTION
Since the latest versions of Chrome, Safari, and Firefox now support the Navigation API, I have updated neouter to utilize this API for routing.

While unsupported browsers will fall back to hard navigation, I consider this acceptable as it doesn't break the core routing functionality. I believe the premium experience is a privilege reserved for users of modern browsers.

---
JA

* 最新のChrome, Safari, FirefoxがNavigation APIに対応したので、neouterもNavigation APIを使ったルーティングに切り替えた
  * 非対応のブラウザではハードナビゲーションになるが、ルーティングができなくなるわけではないので問題ないと判断した。最高のエクスペリエンスは最新のブラウザユーザーの特権である