### PR TITLE
refactor: preloadしてからsetLocationを呼ぶようにした

### DIFF
--- a/packages/neouter/src/context.tsx
+++ b/packages/neouter/src/context.tsx
@@ -55,6 +55,9 @@ export const RouterProvider = ({
             ) {
               await Component.preload()
             }
+
+            if (e.signal.aborted) return
+
             startTransition(() => {
               setLocation(nextPath)
             })

--- a/packages/neouter/src/context.tsx
+++ b/packages/neouter/src/context.tsx
@@ -43,9 +43,6 @@ export const RouterProvider = ({
         const nextPath = destination.pathname + destination.search
         e.intercept({
           async handler() {
-            startTransition(() => {
-              setLocation(nextPath)
-            })
             const matchedPath = getMatchedPath(routes, nextPath)
             const Component = matchedPath
               ? routes[matchedPath]?.component
@@ -58,6 +55,9 @@ export const RouterProvider = ({
             ) {
               await Component.preload()
             }
+            startTransition(() => {
+              setLocation(nextPath)
+            })
           },
         })
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import './global.css'
 import { useCreateRoutes } from 'neouter'
+import { Suspense } from 'react'
 import { Header } from './components/Header'
 import { routes } from './routes'
 
@@ -10,7 +11,9 @@ export const App = () => {
       <div className="mx-auto max-w-[800px] p-4">
         <Header />
         <div className="mt-4">
-          <Router />
+          <Suspense fallback={<p>Loading...</p>}>
+            <Router />
+          </Suspense>
         </div>
       </div>
     </RouterProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
 import './global.css'
 import { useCreateRoutes } from 'neouter'
-import { Suspense } from 'react'
 import { Header } from './components/Header'
 import { routes } from './routes'
 
@@ -11,9 +10,7 @@ export const App = () => {
       <div className="mx-auto max-w-[800px] p-4">
         <Header />
         <div className="mt-4">
-          <Suspense fallback={<div>Loading...</div>}>
-            <Router />
-          </Suspense>
+          <Router />
         </div>
       </div>
     </RouterProvider>

--- a/src/routes/lazy/index.tsx
+++ b/src/routes/lazy/index.tsx
@@ -1,8 +1,24 @@
+import { Suspense, use } from 'react'
+
+const greet = new Promise<string>((resolve) => {
+  setTimeout(() => {
+    resolve('Hello, world!')
+  }, 1000)
+})
+
+const Greeting = () => {
+  const greeting = use(greet)
+  return <p>{greeting}</p>
+}
+
 export const Lazy = () => {
   return (
     <div>
       <title>Lazy</title>
       Lazy
+      <Suspense fallback={<p>Loading...</p>}>
+        <Greeting />
+      </Suspense>
     </div>
   )
 }


### PR DESCRIPTION
- ~~非同期でページを読み込むときはtransitionでレンダリングを保留するようになり、親で宣言していたSuspenseが意味をなさなくなったので削除~~

いや、初回ロード時にSuspenseはあったほうが良い（なくてもよいが）
サンプルとしては残しておいたほうが良いか。

このPRのメインはpreloadしてからsetLocationを呼ぶようにしたこと