### PR TITLE
 Do not mark changes that are only query parameters as a transition

### DIFF
--- a/packages/neouter/src/context.tsx
+++ b/packages/neouter/src/context.tsx
@@ -7,7 +7,7 @@ import {
   useTransition,
 } from 'react'
 import type { Path, Routes } from './types'
-import { getMatchedPath } from './utils'
+import { getMatchedPath, normalizePathname } from './utils'
 
 export const RouterContext = createContext<{
   location: Path
@@ -58,9 +58,18 @@ export const RouterProvider = ({
 
             if (e.signal.aborted) return
 
-            startTransition(() => {
+            const isSamePath =
+              normalizePathname(nextPath) === normalizePathname(location)
+
+            if (
+              isSamePath // Do not mark changes that are only query parameters as a transition
+            ) {
               setLocation(nextPath)
-            })
+            } else {
+              startTransition(() => {
+                setLocation(nextPath)
+              })
+            }
           },
         })
       }
@@ -71,7 +80,7 @@ export const RouterProvider = ({
     } else {
       // Older browsers will perform a full navigation to the new URL
     }
-  }, [routes])
+  }, [routes, location])
 
   return (
     <RouterContext.Provider value={{ location, setLocation, routes }}>

--- a/packages/neouter/src/context.tsx
+++ b/packages/neouter/src/context.tsx
@@ -41,8 +41,21 @@ export const RouterProvider = ({
 
         const destination = new URL(e.destination.url)
         const nextPath = destination.pathname + destination.search
+        const currentPath = new URL(navigation.currentEntry?.url || '')
+        const isSearchChange =
+          normalizePathname(nextPath) ===
+            normalizePathname(window.location.pathname) &&
+          currentPath.search !== destination.search
+
         e.intercept({
           async handler() {
+            if (
+              isSearchChange // Do not mark changes that are only query parameters as a transition
+            ) {
+              setLocation(nextPath)
+              return
+            }
+
             const matchedPath = getMatchedPath(routes, nextPath)
             const Component = matchedPath
               ? routes[matchedPath]?.component
@@ -58,18 +71,9 @@ export const RouterProvider = ({
 
             if (e.signal.aborted) return
 
-            const isSamePath =
-              normalizePathname(nextPath) === normalizePathname(location)
-
-            if (
-              isSamePath // Do not mark changes that are only query parameters as a transition
-            ) {
+            startTransition(() => {
               setLocation(nextPath)
-            } else {
-              startTransition(() => {
-                setLocation(nextPath)
-              })
-            }
+            })
           },
         })
       }
@@ -80,7 +84,7 @@ export const RouterProvider = ({
     } else {
       // Older browsers will perform a full navigation to the new URL
     }
-  }, [routes, location])
+  }, [routes])
 
   return (
     <RouterContext.Provider value={{ location, setLocation, routes }}>


### PR DESCRIPTION
クエリパラメータだけの変更はトグルや検索ボックスなどの制御で使われることが多いものの「ページの遷移」ではないので、トランジションとしてマークするとただSuspenseが行われずにインタラクションが遅れるだけになってしまっている。

なので、normalizePathname で同一パス判定になる（＝クエリパラメータだけ・ハッシュだけの変更）場合はトランジションを挟まないようにした