### PR TITLE
feat: hash link

### DIFF
--- a/packages/neouter/src/hooks/useCreateRoutes.tsx
+++ b/packages/neouter/src/hooks/useCreateRoutes.tsx
@@ -1,7 +1,17 @@
-import { Fragment, useContext, useMemo } from 'react'
+import { Fragment, useContext, useEffect, useMemo } from 'react'
 import { getMatchedPath, normalizePathname } from '../'
 import { RouterContext, RouterProvider } from '../context'
 import type { Routes } from '../types'
+
+const ScrollIntoView = ({ children }: { children: React.ReactNode }) => {
+  useEffect(() => {
+    const hash = window.location.hash
+    if (hash) {
+      document.querySelector(hash)?.scrollIntoView()
+    }
+  }, [])
+  return <>{children}</>
+}
 
 const RouteComponent = ({
   routes,
@@ -17,7 +27,9 @@ const RouteComponent = ({
 
   return (
     <Fragment key={`neouter-${pathname}`}>
-      {Component ? <Component /> : notFoundComponent}
+      <ScrollIntoView>
+        {Component ? <Component /> : notFoundComponent}
+      </ScrollIntoView>
     </Fragment>
   )
 }

--- a/packages/neouter/src/types.ts
+++ b/packages/neouter/src/types.ts
@@ -54,6 +54,7 @@ type ReplaceParams<Path extends string> =
 type AssertPathType<R extends string> = ReplaceParams<R>
 
 type Path =
+  | `#${string}` // for hash links
   | `${string}://${string}` // for external links
   | PathPattern
   | (WithQueryAndHash<AssertPathType<PathPattern>> & { _?: never }) // typescript is bad

--- a/src/global.css
+++ b/src/global.css
@@ -4,8 +4,15 @@
   navigation: auto;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}
+
 html {
   font-family: "Poppins", sans-serif;
+  scroll-behavior: smooth;
 }
 
 .logo {

--- a/src/routes/Heavy/Heavy.tsx
+++ b/src/routes/Heavy/Heavy.tsx
@@ -1,3 +1,4 @@
+/** biome-ignore-all lint/correctness/useUniqueElementIds: hash routing */
 import { Link } from 'neouter'
 import { Layout } from '../../components/Layout'
 import DogAsset from './dog.jpg'
@@ -7,7 +8,7 @@ export const Heavy = () => {
     <Layout>
       <div className="space-y-4">
         <h1 className="text-4xl">Animal World</h1>
-        <p>An example of a heavy page(2MB)</p>
+        <p>An example of a heavy page(2MB) & hash property demo</p>
         <p>This component is heavy because it contains a large image.</p>
         <Link
           href="https://unsplash.com/photos/yellow-labrador-retriever-biting-yellow-tulip-flower-Sg3XwuEpybU"
@@ -20,6 +21,61 @@ export const Heavy = () => {
             className="h-[500px]"
           />
         </Link>
+
+        <nav className="flex flex-col gap-1 pt-6">
+          <h2 className="text-2xl">Contents</h2>
+          <Link href="#s1" className="text-blue-500 underline">
+            Go to Section 1
+          </Link>
+          <Link href="#s2" className="text-blue-500 underline">
+            Go to Section 2
+          </Link>
+          <Link href="#s3" className="text-blue-500 underline">
+            Go to Section 3
+          </Link>
+        </nav>
+
+        <div className="space-y-4 pt-6">
+          <section className="space-y-2" id="s1">
+            <h2 className="text-2xl">Section 1</h2>
+            <p>This is the first section of the about page.</p>
+            <p>
+              I'll talk a little about the weather today. Outside the window,
+              the clouds are drifting slowly, and nothing unusual is happening.
+              As I drink coffee and look at the clock, I feel time passing
+              quietly. The people passing by on the street are as usual, with no
+              special news and the everyday routine continuing. That kind of
+              ordinary calmness is strangely comforting.
+            </p>
+          </section>
+
+          <section className="space-y-2" id="s2">
+            <h2 className="text-2xl">Section 2</h2>
+            <p>This is the second section of the about page.</p>
+            <p>
+              Next is a story about food. I had toast for breakfast, but it
+              wasn't particularly impressive. The saltiness of the butter and
+              the sweetness of the jam were in their usual balance, with no
+              surprises or discoveries. For lunch, I chose a regular set meal at
+              a nearby diner and finished it quietly without anything memorable
+              happening. Peaceful meals are part of life.
+            </p>
+          </section>
+
+          <section className="space-y-2" id="s3">
+            <h2 className="text-2xl">Section 3</h2>
+            <p>This is the last section of the about page.</p>
+            <p>
+              Finally, I'll talk about getting around. Commutes and shopping
+              trips weren't especially crowded, and the train arrived and
+              departed on time. I sat down, looked at my smartphone for a bit,
+              and arrived at my destination. The announcements on the train were
+              calm and matter-of-fact, and nothing in the surrounding
+              conversations stood out. Arriving at my destination without
+              incident is satisfying enough.
+            </p>
+          </section>
+        </div>
       </div>
     </Layout>
   )


### PR DESCRIPTION
ハッシュでのページ内遷移をちゃんと考慮できていなかったので、対応した
- lazyImportなどの影響で初期表示時にハッシュの遷移先が存在しない場合を考慮して、ページのレンダリング後にscrollIntoViewするようにした
- Pathの型でhash linkを考慮するようにした
- デモを追加