### PR TITLE
Fix redirect to destination url if no matched path is found

### DIFF
--- a/packages/neouter/package.json
+++ b/packages/neouter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neouter",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "author": "avaice <avaice@ymail.ne.jp>",
   "keywords": [
     "react",

--- a/packages/neouter/src/context.tsx
+++ b/packages/neouter/src/context.tsx
@@ -47,6 +47,12 @@ export const RouterProvider = ({
             normalizePathname(window.location.pathname) &&
           currentPath.search !== destination.search
 
+        const matchedPath = getMatchedPath(routes, nextPath)
+        if(!matchedPath) {
+          window.location.href = e.destination.url
+          return
+        }
+
         e.intercept({
           async handler() {
             if (
@@ -56,7 +62,8 @@ export const RouterProvider = ({
               return
             }
 
-            const matchedPath = getMatchedPath(routes, nextPath)
+            
+
             const Component = matchedPath
               ? routes[matchedPath]?.component
               : null

--- a/src/routes/_top/Top.tsx
+++ b/src/routes/_top/Top.tsx
@@ -41,6 +41,7 @@ export const Top = () => {
             neouter friends
           </Link>
         </div>
+        <button className='border p-1' onClick={() => location.href = "/api/hoge"}>same-origin-but-out-of-app</button>
       </div>
     </div>
   )


### PR DESCRIPTION
「同じドメインだけどアプリケーションの外」のケースで正しくページ遷移を行えていなかったのを修正